### PR TITLE
Removing Cross-Site Request Forgery filter, since it blocked our POST…

### DIFF
--- a/app/Filters.scala
+++ b/app/Filters.scala
@@ -14,11 +14,11 @@ import play.filters.hosts.AllowedHostsFilter
  * https://www.playframework.com/documentation/latest/SecurityHeaders
  */
 class Filters @Inject() (
-  csrfFilter: CSRFFilter,
+//  csrfFilter: CSRFFilter,
   allowedHostsFilter: AllowedHostsFilter,
   securityHeadersFilter: SecurityHeadersFilter
 ) extends DefaultHttpFilters(
-  csrfFilter, 
+//  csrfFilter,
   allowedHostsFilter, 
   securityHeadersFilter
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,1 +1,2 @@
 # https://www.playframework.com/documentation/latest/Configuration
+


### PR DESCRIPTION
… requests, and it is currently pointless, because we don't have any kind of authorization anyway.